### PR TITLE
CB2-11819: Move SMC prohibition to SNS/SQS pattern

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -23,7 +23,9 @@ const handler = async (
 
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
-        const mcRequests: MCRequest[] = extractMCTestResults(JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord);
+        const dynamoRecord: DynamoDBRecord = JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord;
+
+        const mcRequests: MCRequest[] = extractMCTestResults(dynamoRecord);
         if (mcRequests != null) {
           await sendMCProhibition(mcRequests);
         }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -23,8 +23,9 @@ const handler = async (
 
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
+        logger.debug(record)
         const dynamoRecord: DynamoDBRecord = JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord;
-        console.log(dynamoRecord);
+        logger.debug(dynamoRecord)
         const mcRequests: MCRequest[] = extractMCTestResults(dynamoRecord);
         if (mcRequests != null) {
           await sendMCProhibition(mcRequests);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -22,7 +22,6 @@ const handler = async (
       logger.debug(`Function triggered with '${JSON.stringify(event)}'.`);
 
       for (const record of event.Records) {
-        logger.debug(record)
         const snsRecord: SNSMessage = JSON.parse(record.body) as SNSMessage;
         const dynamoDBEventStr = snsRecord.Message;
         if (dynamoDBEventStr){

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { Context, Callback, SQSEvent } from 'aws-lambda';
+import { Context, Callback, SQSEvent, DynamoDBRecord } from 'aws-lambda';
 import { extractMCTestResults } from './utils/ExtractTestResults';
 import { sendMCProhibition } from './eventbridge/Send';
 import logger from './observability/Logger';
@@ -23,7 +23,7 @@ const handler = async (
 
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
-        const mcRequests: MCRequest[] = extractMCTestResults(JSON.parse(record.body).Message);
+        const mcRequests: MCRequest[] = extractMCTestResults(JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord);
         if (mcRequests != null) {
           await sendMCProhibition(mcRequests);
         }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -22,7 +22,7 @@ const handler = async (
 
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
-        const mcRequests: MCRequest[] = extractMCTestResults(record);
+        const mcRequests: MCRequest[] = extractMCTestResults(JSON.parse(record.body).Message);
         if (mcRequests != null) {
           await sendMCProhibition(mcRequests);
         }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,7 +24,7 @@ const handler = async (
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
         logger.debug(record)
-        const dynamoRecord: DynamoDBRecord = JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord;
+        const dynamoRecord: DynamoDBRecord = JSON.parse(record.body) as DynamoDBRecord;
         logger.debug(dynamoRecord)
         const mcRequests: MCRequest[] = extractMCTestResults(dynamoRecord);
         if (mcRequests != null) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,12 +1,12 @@
 /* eslint-disable */
 
-import { DynamoDBStreamEvent, Context, Callback } from 'aws-lambda';
+import { Context, Callback, SQSEvent } from 'aws-lambda';
 import { extractMCTestResults } from './utils/ExtractTestResults';
 import { sendMCProhibition } from './eventbridge/Send';
 import logger from './observability/Logger';
 import { MCRequest } from './utils/MCRequest';
 const handler = async (
-  event: DynamoDBStreamEvent,
+  event: SQSEvent,
   _context: Context,
   callback: Callback,
 ) => {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -5,6 +5,7 @@ import { extractMCTestResults } from './utils/ExtractTestResults';
 import { sendMCProhibition } from './eventbridge/Send';
 import logger from './observability/Logger';
 import { MCRequest } from './utils/MCRequest';
+
 const handler = async (
   event: SQSEvent,
   _context: Context,

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,7 +24,7 @@ const handler = async (
       // We want to process these in sequence to maintain order of database changes
       for (const record of event.Records) {
         const dynamoRecord: DynamoDBRecord = JSON.parse(JSON.parse(record.body).Message) as DynamoDBRecord;
-
+        console.log(dynamoRecord);
         const mcRequests: MCRequest[] = extractMCTestResults(dynamoRecord);
         if (mcRequests != null) {
           await sendMCProhibition(mcRequests);

--- a/src/utils/ExtractTestResults.ts
+++ b/src/utils/ExtractTestResults.ts
@@ -22,9 +22,9 @@ import { ValidationUtil } from './ValidationUtil';
  * @param record
  */
 export const extractMCTestResults = (record: DynamoDBRecord): MCRequest[] => {
-  console.log('unmarshalling...');
+  logger.debug('unmarshalling...');
   const testResultUnmarshall = unmarshall(record.dynamodb.NewImage as any);
-  console.log(testResultUnmarshall);
+  logger.debug(testResultUnmarshall);
   logger.info(
     `Processing testResultId: ${JSON.stringify(
       testResultUnmarshall.testResultId,

--- a/src/utils/ExtractTestResults.ts
+++ b/src/utils/ExtractTestResults.ts
@@ -22,7 +22,9 @@ import { ValidationUtil } from './ValidationUtil';
  * @param record
  */
 export const extractMCTestResults = (record: DynamoDBRecord): MCRequest[] => {
+  console.log('unmarshalling...');
   const testResultUnmarshall = unmarshall(record.dynamodb.NewImage as any);
+  console.log(testResultUnmarshall);
   logger.info(
     `Processing testResultId: ${JSON.stringify(
       testResultUnmarshall.testResultId,

--- a/src/utils/ExtractTestResults.ts
+++ b/src/utils/ExtractTestResults.ts
@@ -22,9 +22,7 @@ import { ValidationUtil } from './ValidationUtil';
  * @param record
  */
 export const extractMCTestResults = (record: DynamoDBRecord): MCRequest[] => {
-  logger.debug('unmarshalling...');
   const testResultUnmarshall = unmarshall(record.dynamodb.NewImage as any);
-  logger.debug(testResultUnmarshall);
   logger.info(
     `Processing testResultId: ${JSON.stringify(
       testResultUnmarshall.testResultId,

--- a/src/utils/ExtractTestResults.ts
+++ b/src/utils/ExtractTestResults.ts
@@ -8,6 +8,7 @@
 
 import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { DateTime } from 'luxon';
+import { DynamoDBRecord } from 'aws-lambda';
 import { PROHIB_CLEARANCE_TEST_TYPE_IDS } from '../assets/Enums';
 import logger from '../observability/Logger';
 import { HTTPError } from './HTTPError';
@@ -20,8 +21,8 @@ import { ValidationUtil } from './ValidationUtil';
  * required to be sent to MC in order to  clear prohibitions
  * @param record
  */
-export const extractMCTestResults = (record: any): MCRequest[] => {
-  const testResultUnmarshall = unmarshall(record.dynamodb.NewImage as { any });
+export const extractMCTestResults = (record: DynamoDBRecord): MCRequest[] => {
+  const testResultUnmarshall = unmarshall(record.dynamodb.NewImage as any);
   logger.info(
     `Processing testResultId: ${JSON.stringify(
       testResultUnmarshall.testResultId,

--- a/tests/unit/Handler.test.ts
+++ b/tests/unit/Handler.test.ts
@@ -75,43 +75,6 @@ describe('Application entry', () => {
         expect(sendMCProhibition).toHaveBeenCalledWith(expectedMCRequests);
       });
     });
-    it('should handle an empty notification gracefully', async () => {
-      const emptyNotificationEvent: SQSEvent = {
-        Records: [
-          {
-            messageId: '1317d15-a23b2-4c68-a2da-67cc685dda5b',
-            receiptHandle: 'aer3fiu34yufybuy34f334',
-            body: JSON.stringify({
-              Type: 'Notification',
-              MessageId: 'some-message-id',
-            }),
-            attributes: {
-              ApproximateReceiveCount: '1',
-              SentTimestamp: '1717678383236',
-              SenderId: 'AIDAISMY7JYY5F7RTT6AO',
-              ApproximateFirstReceiveTimestamp: '1717678383247',
-            },
-            messageAttributes: {},
-            md5OfBody: '45bd1375e48194d7e1563cf20462d',
-            eventSource: 'aws:sqs',
-            eventSourceARN: 'arn:aws:sqs:eu-west-1:local:cvs-smc-prohibition-local-queue',
-            awsRegion: 'eu-west-1',
-          },
-        ],
-      };
-      const resultPromise = new Promise((resolve, reject) => {
-        handler(emptyNotificationEvent, null, (error, result) => {
-          if (error) reject(error);
-          else resolve(result);
-        });
-      });
-
-      await expect(resultPromise).resolves.toBe(
-        'Function not triggered, empty notification.',
-      );
-      expect(extractMCTestResults).not.toHaveBeenCalled();
-      expect(sendMCProhibition).not.toHaveBeenCalled();
-    });
 
     it('should handle an error when sending the object', async () => {
       process.env.SEND_TO_SMC = 'True';

--- a/tests/unit/Handler.test.ts
+++ b/tests/unit/Handler.test.ts
@@ -1,10 +1,3 @@
-/* eslint-disable import/first */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable import/no-unresolved */
 import { SQSEvent } from 'aws-lambda';
 import { sendMCProhibition } from '../../src/eventbridge/Send';
 import { SendResponse } from '../../src/eventbridge/SendResponse';
@@ -20,20 +13,32 @@ describe('Application entry', () => {
   const event: SQSEvent = {
     Records: [
       {
-        'messageId': '1317d15-a23b2-4c68-a2da-67cc685dda5b',
-        'receiptHandle': 'aer3fiu34yufybuy34f334',
-        'body': JSON.stringify(dynamoRecordFiltered),
-        'attributes': {
-          'ApproximateReceiveCount': '1',
-          'SentTimestamp': '1717678383236',
-          'SenderId': 'AIDAISMY7JYY5F7RTT6AO',
-          'ApproximateFirstReceiveTimestamp': '1717678383247',
+        messageId: '1317d15-a23b2-4c68-a2da-67cc685dda5b',
+        receiptHandle: 'aer3fiu34yufybuy34f334',
+        body: JSON.stringify({
+          Type: 'Notification',
+          MessageId: 'some-message-id',
+          TopicArn: 'arn:aws:sns:us-east-1:123456789012:my-topic',
+          Subject: 'Test Subject',
+          Message: JSON.stringify({
+            eventID: '...',
+            eventName: 'INSERT',
+            dynamodb: {
+              NewImage: dynamoRecordFiltered.dynamodb.NewImage,
+            },
+          }),
+        }),
+        attributes: {
+          ApproximateReceiveCount: '1',
+          SentTimestamp: '1717678383236',
+          SenderId: 'AIDAISMY7JYY5F7RTT6AO',
+          ApproximateFirstReceiveTimestamp: '1717678383247',
         },
-        'messageAttributes': {},
-        'md5OfBody': '45bd1375e48194d7e1563cf20462d',
-        'eventSource': 'aws:sqs',
-        'eventSourceARN': 'arn:aws:sqs:eu-west-1:local:cvs-smc-prohibition-local-queue',
-        'awsRegion': 'eu-west-1',
+        messageAttributes: {},
+        md5OfBody: '45bd1375e48194d7e1563cf20462d',
+        eventSource: 'aws:sqs',
+        eventSourceARN: 'arn:aws:sqs:eu-west-1:local:cvs-smc-prohibition-local-queue',
+        awsRegion: 'eu-west-1',
       },
     ],
   };
@@ -48,43 +53,89 @@ describe('Application entry', () => {
   });
 
   describe('Handler', () => {
-    it('When there is an event that gets processed successfully no errors are produced', async () => {
+    process.env.SEND_TO_SMC = 'True';
+    it('should process a valid event successfully', async () => {
+      const expectedMCRequests: MCRequest[] = [
+        {
+          vehicleIdentifier: 'ABC1234',
+          testDate: '14/01/2019',
+          vin: 'XMGDE02FS0H012303',
+          testResult: 'P',
+          hgvPsvTrailFlag: 'T',
+          testResultId: 'some-test-result-id',
+        },
+      ];
 
+      jest.mocked(extractMCTestResults).mockReturnValue(expectedMCRequests);
       jest.mocked(sendMCProhibition).mockResolvedValue(sendResponse);
-      await handler(event, null, (error: string | Error, result: string) => {
-        expect(result).toBe('Data processed successfully.');
+
+      await handler(event, null, (error, result) => {
         expect(error).toBeNull();
-        expect(sendMCProhibition).toHaveBeenCalledTimes(1);
+        expect(result).toBe('Data processed successfully.');
+        expect(sendMCProhibition).toHaveBeenCalledWith(expectedMCRequests);
       });
     });
-
-    it('When there is an event that gets processed successfully in proper case then no errors are produced', async () => {
-      process.env.SEND_TO_SMC = 'True';
-      jest.mocked(sendMCProhibition).mockResolvedValue(sendResponse);
-      await handler(event, null, (error: string | Error, result: string) => {
-        expect(result).toBe('Data processed successfully.');
-        expect(error).toBeNull();
-        expect(sendMCProhibition).toHaveBeenCalledTimes(1);
+    it('should handle an empty notification gracefully', async () => {
+      const emptyNotificationEvent: SQSEvent = {
+        Records: [
+          {
+            messageId: '1317d15-a23b2-4c68-a2da-67cc685dda5b',
+            receiptHandle: 'aer3fiu34yufybuy34f334',
+            body: JSON.stringify({
+              Type: 'Notification',
+              MessageId: 'some-message-id',
+            }),
+            attributes: {
+              ApproximateReceiveCount: '1',
+              SentTimestamp: '1717678383236',
+              SenderId: 'AIDAISMY7JYY5F7RTT6AO',
+              ApproximateFirstReceiveTimestamp: '1717678383247',
+            },
+            messageAttributes: {},
+            md5OfBody: '45bd1375e48194d7e1563cf20462d',
+            eventSource: 'aws:sqs',
+            eventSourceARN: 'arn:aws:sqs:eu-west-1:local:cvs-smc-prohibition-local-queue',
+            awsRegion: 'eu-west-1',
+          },
+        ],
+      };
+      const resultPromise = new Promise((resolve, reject) => {
+        handler(emptyNotificationEvent, null, (error, result) => {
+          if (error) reject(error);
+          else resolve(result);
+        });
       });
+
+      await expect(resultPromise).resolves.toBe(
+        'Function not triggered, empty notification.',
+      );
+      expect(extractMCTestResults).not.toHaveBeenCalled();
+      expect(sendMCProhibition).not.toHaveBeenCalled();
     });
 
-    it('When there is an error when sending the object and error is produced', async () => {
+    it('should handle an error when sending the object', async () => {
       process.env.SEND_TO_SMC = 'True';
+      const expectedErrorMessage = 'Data processed unsuccessfully: Error: Oh no!';
       jest.mocked(sendMCProhibition).mockRejectedValue(new Error('Oh no!'));
-      await handler(event, null, (error: string | Error, result: string) => {
+
+      await handler(event, null, (error, result) => {
         expect(error).toBeNull();
-        expect(result).toBe('Data processed unsuccessfully: Error: Oh no!');
+        expect(result).toBe(expectedErrorMessage);
         expect(sendMCProhibition).toHaveBeenCalledTimes(1);
       });
     });
 
-    it('When there is an invalid environment variable a log is produced', async () => {
+    it('should handle an invalid environment variable', async () => {
       process.env.SEND_TO_SMC = 'false';
-      jest.spyOn(console, 'log');
-      await handler(event, null, (error: string | Error, result: string) => {
+
+      await handler(event, null, (error, result) => {
         expect(error).toBeNull();
         expect(result).toBe('Function not triggered, Missing or not true environment variable present');
+        expect(extractMCTestResults).not.toHaveBeenCalled();
+        expect(sendMCProhibition).not.toHaveBeenCalled();
       });
     });
   });
 });
+
+

--- a/tests/unit/Handler.test.ts
+++ b/tests/unit/Handler.test.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable import/no-unresolved */
-import { SQSEvent, SQSRecord } from 'aws-lambda';
+import { SQSEvent } from 'aws-lambda';
 import { sendMCProhibition } from '../../src/eventbridge/Send';
 import { SendResponse } from '../../src/eventbridge/SendResponse';
 import { extractMCTestResults } from '../../src/utils/ExtractTestResults';
@@ -17,25 +17,39 @@ jest.mock('../../src/eventbridge/Send');
 jest.mock('../../src/utils/ExtractTestResults');
 
 describe('Application entry', () => {
-  let event: SQSEvent = {
+  const event: SQSEvent = {
     Records: [
-      dynamoRecordFiltered,
-    ] as unknown as SQSRecord[],
+      {
+        'messageId': '1317d15-a23b2-4c68-a2da-67cc685dda5b',
+        'receiptHandle': 'aer3fiu34yufybuy34f334',
+        'body': JSON.stringify(dynamoRecordFiltered),
+        'attributes': {
+          'ApproximateReceiveCount': '1',
+          'SentTimestamp': '1717678383236',
+          'SenderId': 'AIDAISMY7JYY5F7RTT6AO',
+          'ApproximateFirstReceiveTimestamp': '1717678383247',
+        },
+        'messageAttributes': {},
+        'md5OfBody': '45bd1375e48194d7e1563cf20462d',
+        'eventSource': 'aws:sqs',
+        'eventSourceARN': 'arn:aws:sqs:eu-west-1:local:cvs-smc-prohibition-local-queue',
+        'awsRegion': 'eu-west-1',
+      },
+    ],
   };
+  const sendResponse: SendResponse = {
+    SuccessCount: 1,
+    FailCount: 0,
+  };
+
   jest.mocked(extractMCTestResults).mockReturnValue(Array<MCRequest>());
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  beforeAll(() => {
-
-  });
   describe('Handler', () => {
     it('When there is an event that gets processed successfully no errors are produced', async () => {
-      const sendResponse: SendResponse = {
-        SuccessCount: 1,
-        FailCount: 0,
-      };
+
       jest.mocked(sendMCProhibition).mockResolvedValue(sendResponse);
       await handler(event, null, (error: string | Error, result: string) => {
         expect(result).toBe('Data processed successfully.');
@@ -43,12 +57,9 @@ describe('Application entry', () => {
         expect(sendMCProhibition).toHaveBeenCalledTimes(1);
       });
     });
+
     it('When there is an event that gets processed successfully in proper case then no errors are produced', async () => {
       process.env.SEND_TO_SMC = 'True';
-      const sendResponse: SendResponse = {
-        SuccessCount: 1,
-        FailCount: 0,
-      };
       jest.mocked(sendMCProhibition).mockResolvedValue(sendResponse);
       await handler(event, null, (error: string | Error, result: string) => {
         expect(result).toBe('Data processed successfully.');
@@ -56,6 +67,7 @@ describe('Application entry', () => {
         expect(sendMCProhibition).toHaveBeenCalledTimes(1);
       });
     });
+
     it('When there is an error when sending the object and error is produced', async () => {
       process.env.SEND_TO_SMC = 'True';
       jest.mocked(sendMCProhibition).mockRejectedValue(new Error('Oh no!'));
@@ -65,10 +77,10 @@ describe('Application entry', () => {
         expect(sendMCProhibition).toHaveBeenCalledTimes(1);
       });
     });
+
     it('When there is an invalid environment variable a log is produced', async () => {
       process.env.SEND_TO_SMC = 'false';
       jest.spyOn(console, 'log');
-
       await handler(event, null, (error: string | Error, result: string) => {
         expect(error).toBeNull();
         expect(result).toBe('Function not triggered, Missing or not true environment variable present');

--- a/tests/unit/Handler.test.ts
+++ b/tests/unit/Handler.test.ts
@@ -16,17 +16,13 @@ describe('Application entry', () => {
         messageId: '1317d15-a23b2-4c68-a2da-67cc685dda5b',
         receiptHandle: 'aer3fiu34yufybuy34f334',
         body: JSON.stringify({
-          Type: 'Notification',
-          MessageId: 'some-message-id',
-          TopicArn: 'arn:aws:sns:us-east-1:123456789012:my-topic',
-          Subject: 'Test Subject',
-          Message: JSON.stringify({
+          Message: {
             eventID: '...',
             eventName: 'INSERT',
             dynamodb: {
               NewImage: dynamoRecordFiltered.dynamodb.NewImage,
             },
-          }),
+          },
         }),
         attributes: {
           ApproximateReceiveCount: '1',


### PR DESCRIPTION
## Subscribe smc-prohibition to test result SNS contract 
This change is to change the incoming event to be the SQS event instead the dynamodb stream

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-11819)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number